### PR TITLE
Refactor: Move Less Function from Interface to Standalone Function

### DIFF
--- a/compactor/compactor.go
+++ b/compactor/compactor.go
@@ -21,7 +21,7 @@ func Compact(w io.ReadWriteSeeker, sequences ...loser.Sequence[partition.Record]
 	}
 
 	var (
-		lt   = loser.New[partition.Record](sequences, partition.Max)
+		lt   = loser.New[partition.Record](sequences, partition.Max, partition.Less)
 		last partition.Record
 		bw   = sst.BatchWriter()
 		done bool

--- a/compactor/compactor_test.go
+++ b/compactor/compactor_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type List[E loser.Lesser[E]] struct {
+type List[E any] struct {
 	list []E
 }
 
-func NewList[E loser.Lesser[E]](list ...E) *List[E] {
+func NewList[E any](list ...E) *List[E] {
 	return &List[E]{list: list}
 }
 

--- a/loser/loser_test.go
+++ b/loser/loser_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/davidvella/xp/loser"
 )
 
-type List[E loser.Lesser[E]] struct {
+type List[E any] struct {
 	list []E
 }
 
-func NewList[E loser.Lesser[E]](list ...E) *List[E] {
+func NewList[E any](list ...E) *List[E] {
 	return &List[E]{list: list}
 }
 
@@ -24,7 +24,7 @@ func (it *List[E]) All() iter.Seq[E] {
 	}
 }
 
-func checkIterablesEqual[E loser.Lesser[E]](t *testing.T, a, b loser.Sequence[E]) {
+func checkIterablesEqual[E any](t *testing.T, a, b loser.Sequence[E], less func(a, b E) bool) {
 	t.Helper()
 	count := 0
 	next, stop := iter.Pull(b.All())
@@ -35,7 +35,7 @@ func checkIterablesEqual[E loser.Lesser[E]](t *testing.T, a, b loser.Sequence[E]
 		if !ok {
 			t.Fatalf("b ended before a after %d elements", count)
 		}
-		if va.Less(vb) || vb.Less(va) {
+		if less(va, vb) || less(vb, va) {
 			t.Fatalf("position %d: %v != %v", count, va, vb)
 		}
 	}
@@ -92,14 +92,14 @@ func TestMerge(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lt := loser.New[Uint64](tt.args, math.MaxUint64)
-			checkIterablesEqual(t, tt.want, lt)
+			lt := loser.New[Uint64](tt.args, math.MaxUint64, Less)
+			checkIterablesEqual(t, tt.want, lt, Less)
 		})
 	}
 }
 
 type Uint64 uint64
 
-func (u Uint64) Less(other Uint64) bool {
+func Less(u, other Uint64) bool {
 	return u < other
 }

--- a/partition/partition.go
+++ b/partition/partition.go
@@ -41,7 +41,7 @@ func (r RecordImpl) GetData() []byte {
 	return r.Data
 }
 
-func (r RecordImpl) Less(t Record) bool {
+func Less(r, t Record) bool {
 	if c := cmp.Compare(r.GetPartitionKey(), t.GetPartitionKey()); c < 0 {
 		return true
 	}
@@ -58,7 +58,6 @@ func (r RecordImpl) Less(t Record) bool {
 }
 
 type Record interface {
-	Less(t Record) bool
 	GetID() string
 	GetPartitionKey() string
 	GetWatermark() time.Time

--- a/wal/reader.go
+++ b/wal/reader.go
@@ -38,7 +38,7 @@ func (r *Reader) ReadAll() iter.Seq[partition.Record] {
 		sequences = append(sequences, reader)
 	}
 
-	tree := loser.New(sequences, partition.Max)
+	tree := loser.New(sequences, partition.Max, partition.Less)
 	return tree.All()
 }
 

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -89,7 +89,7 @@ func TestWAL(t *testing.T) {
 			// Verify records are in order
 			if len(readRecords) > 1 {
 				for i := 0; i < len(readRecords)-1; i++ {
-					assert.False(t, readRecords[i+1].Less(readRecords[i]),
+					assert.False(t, partition.Less(readRecords[i+1], readRecords[i]),
 						"Records should be in ascending order")
 				}
 			}
@@ -199,7 +199,7 @@ func TestWALPersistence(t *testing.T) {
 
 		// Verify records are in order
 		for i := 0; i < len(readRecords)-1; i++ {
-			assert.False(t, readRecords[i+1].Less(readRecords[i]),
+			assert.False(t, partition.Less(readRecords[i+1], readRecords[i]),
 				"Records should be in ascending order")
 		}
 	}()

--- a/wal/writer.go
+++ b/wal/writer.go
@@ -48,9 +48,7 @@ func NewWriter(wc io.WriteCloser, maxRecords int) (*Writer, error) {
 
 func (w *Writer) newSegment() {
 	seg := &segment{
-		records: btree.NewG[partition.Record](2, func(a, b partition.Record) bool {
-			return a.Less(b)
-		}),
+		records: btree.NewG[partition.Record](2, partition.Less),
 	}
 	w.currentSegment.Store(seg)
 }


### PR DESCRIPTION
Changes
This PR refactors how we handle comparisons in our loser tree implementation and related components by:
Removing the Lesser[T] interface and moving comparison logic to standalone functions
Simplifying generic constraints by removing the Lesser[T] bound
Adding an explicit comparison function parameter to the loser tree constructor