### PR TITLE
Rename seq to match sstable

### DIFF
--- a/wal/reader.go
+++ b/wal/reader.go
@@ -21,7 +21,7 @@ func NewReader(r io.ReaderAt) *Reader {
 	}
 }
 
-func (r *Reader) ReadAll() iter.Seq[partition.Record] {
+func (r *Reader) All() iter.Seq[partition.Record] {
 	err := r.readExistingSegments()
 	if err != nil {
 		return nil

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -79,7 +79,7 @@ func TestWAL(t *testing.T) {
 			reader := wal.NewReader(f)
 			// Read all records
 			var readRecords []partition.Record
-			for record := range reader.ReadAll() {
+			for record := range reader.All() {
 				readRecords = append(readRecords, record)
 			}
 
@@ -181,7 +181,7 @@ func TestWALPersistence(t *testing.T) {
 
 		// Read all records
 		var readRecords []partition.Record
-		for record := range reader.ReadAll() {
+		for record := range reader.All() {
 			readRecords = append(readRecords, record)
 		}
 
@@ -400,7 +400,7 @@ func TestWALLargeFileRead(t *testing.T) {
 		reader := wal.NewReader(f)
 		count := 0
 		current := "a"
-		for record := range reader.ReadAll() {
+		for record := range reader.All() {
 			// Verify record order
 			require.Equal(t, fmt.Sprintf("test-%s", current), record.GetID())
 			assert.Equal(t, "test-partition", record.GetPartitionKey())


### PR DESCRIPTION
Rename the ReadAll() method to All() in the WAL reader 

Update all test cases to use the new All() method name No functional changes, just method renaming for consistency 

This change improves API consistency across the codebase by using the same method name (All()) for similar iterator functionality in both the SSTable and WAL implementations.